### PR TITLE
Typo

### DIFF
--- a/docs/_src/language/fields.md
+++ b/docs/_src/language/fields.md
@@ -60,7 +60,7 @@ Dimensions are defined using expressions that contain no
 aggregate functions.
 
 ```malloy
-expore: users is table('malloy-data.ecomm.users') {
+source: users is table('malloy-data.ecomm.users') {
   dimension: full_name is concat(first_name, ' ', last_name)
 }
 ```


### PR DESCRIPTION
Easy for us LookML aficionados to start with "expore" (sic) instead of "source" or "query".   Love this language!