### PR TITLE
Update broken links on Key Features page

### DIFF
--- a/docs/_src/about/features.md
+++ b/docs/_src/about/features.md
@@ -8,8 +8,8 @@ produce SQL.
 
 ### Filtering Data
 The first step in working with data, often is isolating the data you are interested in.
-Malloy introduces [simplified filtering](language/filters.md) for all types and allows these filters to be
-applied.  [Time calculations](language/time-ranges.md) are powerful and understandable.
+Malloy introduces [simplified filtering](../language/filters.md) for all types and allows these filters to be
+applied.  [Time calculations](../language/expressions.md#time-expressions) are powerful and understandable.
 
 ### Reusable Aggregates
 In a Malloy Data Model, an aggregate computation need only be defined once (for example revenue).  Once defined, it can be used
@@ -27,7 +27,7 @@ of data lets you access and correctly perform computations and any place in the 
 ### Reusable Queries
 Queries can be introduced into a Malloy model and accessed by name.  One benefit is that the
 queries are always accurate.  Think of a Malloy model as a data function library.
-Queries can also be used to create [nested subtables](nesting.md) in other queries.
+Queries can also be used to create [nested subtables](../language/nesting.md) in other queries.
 
 ### Aggregating Subqueries
 Malloy easily produces nested results.  Entire dashboards can be fetched in a single query.


### PR DESCRIPTION
All three links in the body of the [Key Features ](https://malloydata.github.io/documentation/about/features.html) docs page are broken, reflecting an older directory structure and inadvertently linking to the [What is Malloy](https://malloydata.github.io/documentation/index.html) page. The links have been updated as follows:

- "simplified filtering" now points to https://malloydata.github.io/documentation/language/filters.html
- "time calculations" to https://malloydata.github.io/documentation/language/expressions.html#time-expressions
- "nested subtables" to https://malloydata.github.io/documentation/language/nesting.html