### PR TITLE
Audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "dev": true
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
@@ -1344,9 +1350,9 @@
       "dev": true
     },
     "node_modules/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dev": true,
       "dependencies": {
         "internmap": "1 - 2"
@@ -1365,9 +1371,9 @@
       }
     },
     "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dev": true,
       "dependencies": {
         "delaunator": "5"
@@ -2861,9 +2867,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4649,9 +4655,9 @@
       }
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "dev": true
     },
     "node_modules/rw": {
@@ -4735,9 +4741,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -5112,9 +5118,9 @@
       "dev": true
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -5518,85 +5524,85 @@
       }
     },
     "node_modules/vega": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.22.1.tgz",
-      "integrity": "sha512-KJBI7OWSzpfCPbmWl3GQCqBqbf2TIdpWS0mzO6MmWbvdMhWHf74P9IVnx1B1mhg0ZTqWFualx9ZYhWzMMwudaQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.25.0.tgz",
+      "integrity": "sha512-lr+uj0mhYlSN3JOKbMNp1RzZBenWp9DxJ7kR3lha58AFNCzzds7pmFa7yXPbtbaGhB7Buh/t6n+Bzk3Y0VnF5g==",
       "dev": true,
       "dependencies": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.2",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.2",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.2.0",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.9.0",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.2",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.2",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "dev": true
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.0.tgz",
-      "integrity": "sha512-aiOJcvVpiEDIu5uNc4Kf1hakkkPaVOO5fw5T4RSFAw6GEDbdqcB6eZ1xePcsLVic1hxYD5SGiUPdiiIs0SMh2g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "dev": true,
       "dependencies": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.0.tgz",
-      "integrity": "sha512-etv2BHuCn9bzEc0cxyA2TnbtcAFQGVFmsaqmB4sgBCaqTSEfXMoX68LK3yxBrsdm5LU+y3otJVoewi3qWYCx2g==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.2.tgz",
+      "integrity": "sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
       "dev": true
     },
     "node_modules/vega-expression": {
@@ -5610,79 +5616,95 @@
       }
     },
     "node_modules/vega-force": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.1.0.tgz",
-      "integrity": "sha512-Sssf8iH48vYlz+E7/RpU+SUaJbuLoIL87U4tG2Av4gf/hRiImU49x2TI3EuhFWg1zpaCFxlz0CAaX++Oh/gjdw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "dev": true,
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.0.tgz",
-      "integrity": "sha512-6mgpeWw8yGdG0Zdi8aVkx5oUrpJGOpNxqazC2858RSDPvChM/jDFlgRMTYw52qk7cxU0L08ARp4BwmXaI75j0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.0.tgz",
-      "integrity": "sha512-Mf53zNyx+c9fFqagEI0T8zc9nMlx0zozOngr8oOpG1tZDKOgwOnUgN99zQKbLHjyv+UzWrq3LYTnSLyVe0ZmhQ==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.2.tgz",
+      "integrity": "sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.1.0",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-functions/node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/vega-functions/node_modules/vega-expression": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.0.tgz",
-      "integrity": "sha512-3YX41y+J5pu0PMjvBCASg0/lgvu9+QXWJZ+vl6FFKa8AlsIopQ67ZL7ObwqjZcoZMolJ4q0rc+ZO8aj1pXCYcw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.0.tgz",
-      "integrity": "sha512-DWBK39IEt4FiQru12twzKSFUvFFZ7KtlH9+lAaqrJnKuIZFCyQ1XOUfKScfbKIlk4KS+DuCTNLI/pxC/f7Sk9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "dev": true,
       "dependencies": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.0.tgz",
-      "integrity": "sha512-1prOqkCAfXaUvMqavbGI0nbYGqV8UQR9qvuVwrPJ6Yxm3GIUIOA/JRqNY8eZR8USwMP/kzsqlfVEixj9+Y75VQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "dev": true,
       "dependencies": {
         "vega-canvas": "^1.2.6",
@@ -5722,105 +5744,112 @@
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.0.tgz",
-      "integrity": "sha512-EkAyzbx0pCYxH3v3wghGVCaKINWxHfgbQ2pYDiYv0yo8e04S8Mv/IlRGTt6BAe7cLhrk1WZ4zh20QOppnGG05w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "dev": true,
       "dependencies": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "dev": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.5.0.tgz",
-      "integrity": "sha512-aob7qojh555x3hQWZ/tr8cIJNSWQbm6EoWTJaheZgFOY2x3cDa4Qrg3RJbGw6KwVj/IQk2p40paRzixKZ2kr+A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "dev": true,
       "dependencies": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.0.tgz",
-      "integrity": "sha512-09K0RemY6cdaXBAyakDUNFfEkRcLkGjkDJyWQPAUqGK59hV2J+G3i4uxkZp18Vu0t8oqU7CgzwWim1s5uEpOcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.2.0.tgz",
+      "integrity": "sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
-        "vega-statistics": "^1.7.9",
+        "vega-statistics": "^1.9.0",
         "vega-util": "^1.15.2"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "dev": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.2.0.tgz",
-      "integrity": "sha512-QYltO/otrZHLrCGGf06Y99XtPtqWXITr6rw7rO9oL+l3d9o5RFl9sjHrVxiM7v+vGoZVWbBd5IPbFhPsXZ6+TA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.1.tgz",
-      "integrity": "sha512-takIpkmNxYHhJYALOYzhTin3EDzbys6U4g+l1yJZVlXG9YTdiCMuEVAdtaQOCqF9/7qytD6pCrMxJY2HaoN0qQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "dev": true,
       "dependencies": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-selections": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.0.tgz",
-      "integrity": "sha512-Un3JdLDPjIpF9Dh4sw6m1c/QAcfam6m1YXHJ9vJxE/GdJ+sOrPxc7bcEU8VhOmTUN7IQUn4/1ry4JqqOVMbEhw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "3.1.1",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
+    "node_modules/vega-selections/node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
     "node_modules/vega-selections/node_modules/d3-array": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.1.tgz",
-      "integrity": "sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
       "dev": true,
       "dependencies": {
         "internmap": "1 - 2"
@@ -5829,105 +5858,148 @@
         "node": ">=12"
       }
     },
-    "node_modules/vega-statistics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.0.tgz",
-      "integrity": "sha512-dl+LCRS6qS4jWDme/NEdPVt5r649uB4IK6Kyr2/czmGA5JqjuFmtQ9lHQOnRu8945XLkqLf+JIQQo7vnw+nslA==",
+    "node_modules/vega-selections/node_modules/vega-expression": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.0.tgz",
-      "integrity": "sha512-Q9/l3S6Br1RPX5HZvyLD/cQ4K6K8DtpR09/1y7D66gxNorg2+HGzYZINH9nUvN3mxoXcBWg4cCUh3+JvmkDaEg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.0.tgz",
-      "integrity": "sha512-Yk6ByzVq5F2niFfPlSsrU5wi+NZhsF7IBpJCcTfms4U7eoyNepUXagdFEJ3VWBD/Lit6GorLXFgO17NYcyS5gg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.2.tgz",
+      "integrity": "sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-typings": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.3.tgz",
-      "integrity": "sha512-PREcya3nXT9Tk7xU0IhEpOLVTlqizNtKXV55NhI6ApBjJtqVYbJL7IBh2ckKxGBy3YeUQ37BQZl56UqqiYVWBw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.2.tgz",
+      "integrity": "sha512-fW02GElYoqweCCaPqH6iH44UZnzXiX9kbm1qyecjU3k5s0vtufLI7Yuz/a/uL37mEAqTMQplBBAlk0T9e2e1Dw==",
       "dev": true,
       "dependencies": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "7946.0.4",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-typings/node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/vega-typings/node_modules/vega-expression": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==",
       "dev": true
     },
     "node_modules/vega-view": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.0.tgz",
-      "integrity": "sha512-MI9NTRFmtFX6ADk6KOHhi8bhHjC9pPm42Bj2+74c6l1d3NQZf9Jv7lkiGqKohdkQDNH9LPwz/6slhKwPU9JdkQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "dev": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "dev": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.0.tgz",
-      "integrity": "sha512-1iuNAVZgUHRlBpdq4gSga3KlQmrgFfwy+KpyDgPLQ8HbLkhcVeT7RDh2L6naluqD7Op0xVLms3clR920WsYryQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "dev": true,
       "dependencies": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "dev": true,
       "dependencies": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega/node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/vega/node_modules/vega-expression": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vfile": {
@@ -6102,9 +6174,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6664,6 +6736,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/geojson": {
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "dev": true
     },
     "@types/jsdom": {
       "version": "20.0.0",
@@ -7348,9 +7426,9 @@
       }
     },
     "d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dev": true,
       "requires": {
         "internmap": "1 - 2"
@@ -7363,9 +7441,9 @@
       "dev": true
     },
     "d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dev": true,
       "requires": {
         "delaunator": "5"
@@ -8458,9 +8536,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9683,9 +9761,9 @@
       }
     },
     "robust-predicates": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "dev": true
     },
     "rw": {
@@ -9748,9 +9826,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "set-blocking": {
@@ -10046,9 +10124,9 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
@@ -10334,85 +10412,103 @@
       }
     },
     "vega": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.22.1.tgz",
-      "integrity": "sha512-KJBI7OWSzpfCPbmWl3GQCqBqbf2TIdpWS0mzO6MmWbvdMhWHf74P9IVnx1B1mhg0ZTqWFualx9ZYhWzMMwudaQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.25.0.tgz",
+      "integrity": "sha512-lr+uj0mhYlSN3JOKbMNp1RzZBenWp9DxJ7kR3lha58AFNCzzds7pmFa7yXPbtbaGhB7Buh/t6n+Bzk3Y0VnF5g==",
       "dev": true,
       "requires": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.2",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.2",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.2.0",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.9.0",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.2",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.2",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+          "dev": true
+        },
+        "vega-expression": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+          "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "vega-util": "^1.17.1"
+          }
+        }
       }
     },
     "vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "dev": true
     },
     "vega-crossfilter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.0.tgz",
-      "integrity": "sha512-aiOJcvVpiEDIu5uNc4Kf1hakkkPaVOO5fw5T4RSFAw6GEDbdqcB6eZ1xePcsLVic1hxYD5SGiUPdiiIs0SMh2g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "dev": true,
       "requires": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-encode": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.0.tgz",
-      "integrity": "sha512-etv2BHuCn9bzEc0cxyA2TnbtcAFQGVFmsaqmB4sgBCaqTSEfXMoX68LK3yxBrsdm5LU+y3otJVoewi3qWYCx2g==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.2.tgz",
+      "integrity": "sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
       "dev": true
     },
     "vega-expression": {
@@ -10426,79 +10522,97 @@
       }
     },
     "vega-force": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.1.0.tgz",
-      "integrity": "sha512-Sssf8iH48vYlz+E7/RpU+SUaJbuLoIL87U4tG2Av4gf/hRiImU49x2TI3EuhFWg1zpaCFxlz0CAaX++Oh/gjdw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "dev": true,
       "requires": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.0.tgz",
-      "integrity": "sha512-6mgpeWw8yGdG0Zdi8aVkx5oUrpJGOpNxqazC2858RSDPvChM/jDFlgRMTYw52qk7cxU0L08ARp4BwmXaI75j0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-functions": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.0.tgz",
-      "integrity": "sha512-Mf53zNyx+c9fFqagEI0T8zc9nMlx0zozOngr8oOpG1tZDKOgwOnUgN99zQKbLHjyv+UzWrq3LYTnSLyVe0ZmhQ==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.2.tgz",
+      "integrity": "sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.1.0",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+          "dev": true
+        },
+        "vega-expression": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+          "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "vega-util": "^1.17.1"
+          }
+        }
       }
     },
     "vega-geo": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.0.tgz",
-      "integrity": "sha512-3YX41y+J5pu0PMjvBCASg0/lgvu9+QXWJZ+vl6FFKa8AlsIopQ67ZL7ObwqjZcoZMolJ4q0rc+ZO8aj1pXCYcw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-hierarchy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.0.tgz",
-      "integrity": "sha512-DWBK39IEt4FiQru12twzKSFUvFFZ7KtlH9+lAaqrJnKuIZFCyQ1XOUfKScfbKIlk4KS+DuCTNLI/pxC/f7Sk9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "dev": true,
       "requires": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-label": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.0.tgz",
-      "integrity": "sha512-1prOqkCAfXaUvMqavbGI0nbYGqV8UQR9qvuVwrPJ6Yxm3GIUIOA/JRqNY8eZR8USwMP/kzsqlfVEixj9+Y75VQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "dev": true,
       "requires": {
         "vega-canvas": "^1.2.6",
@@ -10526,211 +10640,247 @@
       }
     },
     "vega-loader": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.0.tgz",
-      "integrity": "sha512-EkAyzbx0pCYxH3v3wghGVCaKINWxHfgbQ2pYDiYv0yo8e04S8Mv/IlRGTt6BAe7cLhrk1WZ4zh20QOppnGG05w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "dev": true,
       "requires": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "dev": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-projection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.5.0.tgz",
-      "integrity": "sha512-aob7qojh555x3hQWZ/tr8cIJNSWQbm6EoWTJaheZgFOY2x3cDa4Qrg3RJbGw6KwVj/IQk2p40paRzixKZ2kr+A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "dev": true,
       "requires": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "vega-regression": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.0.tgz",
-      "integrity": "sha512-09K0RemY6cdaXBAyakDUNFfEkRcLkGjkDJyWQPAUqGK59hV2J+G3i4uxkZp18Vu0t8oqU7CgzwWim1s5uEpOcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.2.0.tgz",
+      "integrity": "sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
-        "vega-statistics": "^1.7.9",
+        "vega-statistics": "^1.9.0",
         "vega-util": "^1.15.2"
       }
     },
     "vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "dev": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scale": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.2.0.tgz",
-      "integrity": "sha512-QYltO/otrZHLrCGGf06Y99XtPtqWXITr6rw7rO9oL+l3d9o5RFl9sjHrVxiM7v+vGoZVWbBd5IPbFhPsXZ6+TA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scenegraph": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.1.tgz",
-      "integrity": "sha512-takIpkmNxYHhJYALOYzhTin3EDzbys6U4g+l1yJZVlXG9YTdiCMuEVAdtaQOCqF9/7qytD6pCrMxJY2HaoN0qQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "dev": true,
       "requires": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-selections": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.0.tgz",
-      "integrity": "sha512-Un3JdLDPjIpF9Dh4sw6m1c/QAcfam6m1YXHJ9vJxE/GdJ+sOrPxc7bcEU8VhOmTUN7IQUn4/1ry4JqqOVMbEhw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "dev": true,
       "requires": {
-        "d3-array": "3.1.1",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+          "dev": true
+        },
         "d3-array": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.1.tgz",
-          "integrity": "sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
           "dev": true,
           "requires": {
             "internmap": "1 - 2"
+          }
+        },
+        "vega-expression": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+          "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "vega-util": "^1.17.1"
           }
         }
       }
     },
     "vega-statistics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.0.tgz",
-      "integrity": "sha512-dl+LCRS6qS4jWDme/NEdPVt5r649uB4IK6Kyr2/czmGA5JqjuFmtQ9lHQOnRu8945XLkqLf+JIQQo7vnw+nslA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1"
+        "d3-array": "^3.2.2"
       }
     },
     "vega-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.0.tgz",
-      "integrity": "sha512-Q9/l3S6Br1RPX5HZvyLD/cQ4K6K8DtpR09/1y7D66gxNorg2+HGzYZINH9nUvN3mxoXcBWg4cCUh3+JvmkDaEg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-transforms": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.0.tgz",
-      "integrity": "sha512-Yk6ByzVq5F2niFfPlSsrU5wi+NZhsF7IBpJCcTfms4U7eoyNepUXagdFEJ3VWBD/Lit6GorLXFgO17NYcyS5gg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.2.tgz",
+      "integrity": "sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-typings": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.3.tgz",
-      "integrity": "sha512-PREcya3nXT9Tk7xU0IhEpOLVTlqizNtKXV55NhI6ApBjJtqVYbJL7IBh2ckKxGBy3YeUQ37BQZl56UqqiYVWBw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.2.tgz",
+      "integrity": "sha512-fW02GElYoqweCCaPqH6iH44UZnzXiX9kbm1qyecjU3k5s0vtufLI7Yuz/a/uL37mEAqTMQplBBAlk0T9e2e1Dw==",
       "dev": true,
       "requires": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "7946.0.4",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+          "dev": true
+        },
+        "vega-expression": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+          "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "vega-util": "^1.17.1"
+          }
+        }
       }
     },
     "vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==",
       "dev": true
     },
     "vega-view": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.0.tgz",
-      "integrity": "sha512-MI9NTRFmtFX6ADk6KOHhi8bhHjC9pPm42Bj2+74c6l1d3NQZf9Jv7lkiGqKohdkQDNH9LPwz/6slhKwPU9JdkQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "dev": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "dev": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-voronoi": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.0.tgz",
-      "integrity": "sha512-1iuNAVZgUHRlBpdq4gSga3KlQmrgFfwy+KpyDgPLQ8HbLkhcVeT7RDh2L6naluqD7Op0xVLms3clR920WsYryQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "dev": true,
       "requires": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "dev": true,
       "requires": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vfile": {
@@ -10860,9 +11010,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wordwrap": {


### PR DESCRIPTION
Dependabot opened a bunch of branches that won't compile, doing an end run.


```
# npm audit report

semver  <5.7.2 || >=6.0.0 <6.3.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix`
node_modules/make-dir/node_modules/semver
node_modules/semver

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
fix available via `npm audit fix`
node_modules/tough-cookie

vega  <=5.22.1
Severity: moderate
Vega Expression Language `scale` expression function Cross Site Scripting - https://github.com/advisories/GHSA-4vq7-882g-wcg4
Vega has Cross-site Scripting vulnerability in `lassoAppend` function - https://github.com/advisories/GHSA-w5m3-xh75-mp55
fix available via `npm audit fix`
node_modules/vega

vega-functions  <=5.13.0
Severity: moderate
Vega Expression Language `scale` expression function Cross Site Scripting - https://github.com/advisories/GHSA-4vq7-882g-wcg4
Vega has Cross-site Scripting vulnerability in `lassoAppend` function - https://github.com/advisories/GHSA-w5m3-xh75-mp55
fix available via `npm audit fix`
node_modules/vega-functions

word-wrap  <1.2.4
Severity: moderate
word-wrap vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-j8xg-fqg3-53r7
```