### PR TITLE
Build and watch launcher.

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -16,6 +16,7 @@
   # search for the extension on https://open-vsx.org/ and use "publisher.id"
   idx.extensions = [
     "malloydata.malloy-vscode"
+    "ms-vscode.js-debug"
   ];
 
     idx.previews = {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "configurations": [
+      {
+        "name": "Build and Watch",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceRoot}",
+        "runtimeExecutable": "npm",
+        "runtimeArgs": ["run", "build-watch"]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Allow launching `build-watch` from within VS Code