### PR TITLE
Add ability to set image preview to a blog post

### DIFF
--- a/layouts/blog.html
+++ b/layouts/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     {{#if page.previewImage }}
-    <meta property="og:image" content="https://malloydata.github.io/{{ page.previewImage }}" />
+    <meta property="og:image" content="https://malloydata.github.io{{ page.previewImage }}" />
     {{/if}}
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/css/document.css" />

--- a/layouts/blog.html
+++ b/layouts/blog.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    {{#if page.previewImage}}
+      <meta property="og:image" content="{{ page.previewImage }}" />
+    {{/if}}
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/css/document.css" />
     <link

--- a/layouts/blog.html
+++ b/layouts/blog.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    {{#if page.previewImage}}
-      <meta property="og:image" content="{{ page.previewImage }}" />
+    {{#if page.previewImage }}
+    <meta property="og:image" content="https://malloydata.github.io/{{ page.previewImage }}" />
     {{/if}}
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/css/document.css" />

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -121,6 +121,8 @@ async function compileDoc(file: string, footers: Record<string, string>): Promis
     const layoutName = frontmatter.layout ?? isBlog ? "blog.html" : "documentation.html";
     const nextBlog = nextPost(shortPath);
     const prevBlog = previoustPost(shortPath);
+    const previewImage = getPreviewImage(shortPath);
+
     // TODO validate that layout exists and log an error if not.
     const compiledPage = LAYOUTS[layoutName]({
       ...DEFAULT_CONTEXT,
@@ -132,7 +134,7 @@ async function compileDoc(file: string, footers: Record<string, string>): Promis
         content: renderedDocument,
         footer: isBlog ? undefined : footers[shortPath],
         nextPost: nextBlog,
-        previousPost: prevBlog
+        previousPost: prevBlog,
       }
     });
     fs.writeFileSync(path.join(OUT_PATH, shortOutPath), compiledPage);
@@ -168,6 +170,7 @@ interface BlogPostInfoRaw {
   author: string;
   subtitle?: string;
   published: string;
+  previewImage?: string;
 }
 
 interface BlogPostInfo {
@@ -176,6 +179,7 @@ interface BlogPostInfo {
   author: string;
   published: Date;
   subtitle?: string;
+  previewImage?: string;
 }
 
 let BLOG_POSTS: BlogPostInfo[] = [];
@@ -418,6 +422,15 @@ function nextPost(blogShortPath: string) {
 function blogTitle(blogShortPath: string) {
   const title = BLOG_POSTS.find(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length))?.title;
   return title ? title : "Malloy Blog";
+}
+
+function getPreviewImage(blogShortPath: string) {
+  const current = BLOG_POSTS.findIndex(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length));
+  const post_path = `${DEFAULT_CONTEXT.site.baseurl}/blog/${BLOG_POSTS[current].path}`
+
+  if (BLOG_POSTS[current].previewImage) {
+    return `${post_path}/${BLOG_POSTS[current].previewImage}`
+  }
 }
 
 function previoustPost(blogShortPath: string) {

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -135,6 +135,7 @@ async function compileDoc(file: string, footers: Record<string, string>): Promis
         footer: isBlog ? undefined : footers[shortPath],
         nextPost: nextBlog,
         previousPost: prevBlog,
+        previewImage: previewImage
       }
     });
     fs.writeFileSync(path.join(OUT_PATH, shortOutPath), compiledPage);
@@ -426,9 +427,9 @@ function blogTitle(blogShortPath: string) {
 
 function getPreviewImage(blogShortPath: string) {
   const current = BLOG_POSTS.findIndex(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length));
-  const post_path = `${DEFAULT_CONTEXT.site.baseurl}/blog/${BLOG_POSTS[current].path}`
 
-  if (BLOG_POSTS[current].previewImage) {
+  if (current !== -1 && BLOG_POSTS[current].previewImage) {
+    const post_path = `${DEFAULT_CONTEXT.site.baseurl}/blog${BLOG_POSTS[current].path}`
     return `${post_path}/${BLOG_POSTS[current].previewImage}`
   }
 }

--- a/src/blog_posts.json
+++ b/src/blog_posts.json
@@ -11,7 +11,8 @@
     "path": "/2023-11-06-beyond-yaml",
     "subtitle": "The easy thing is not always the right thing",
     "author": "Carlin Eng",
-    "published": "2023-11-06"
+    "published": "2023-11-06",
+    "previewImage": "no_yaml_small.png"
   },
   {
     "title": "Bump charts",


### PR DESCRIPTION
I want the ability to control which image shows up when I post a link to social media. On my last post, LinkedIn by default chose the "largest" image on the page, which ended up looking really weird (see screenshot).

![image](https://github.com/malloydata/malloydata.github.io/assets/79773/3ea48717-4c9e-42b5-98a3-0d5c9a7aa8b9)

@christopherswenson let me know if this approach is OK with you.