### PR TITLE
Fix model tag propagation to prevent `##(docs) hidden` from affecting subsequent cells

### DIFF
--- a/scripts/run_code.ts
+++ b/scripts/run_code.ts
@@ -37,6 +37,7 @@ import {
   Connection,
   Result,
   ModelDef,
+  Tag,
 } from "@malloydata/malloy";
 import { DuckDBConnection } from "@malloydata/db-duckdb";
 import path from "path";
@@ -320,7 +321,12 @@ export async function runNotebookCode(
     ._loadModelFromModelDef(modelDef)
     .extendModel(fakeURL);
   const model = await newModel.getModel();
-  const modelTagParse = model.tagParse({ prefix: DOCS_M_TAG_PREFIX });
+  // TODO this is a quick hack to make each snippet only use its own
+  // tags and not those from other cells, unsure if this is the right approach
+  // long term, but it prevents `##(docs) hidden` from affecting subsequent cells
+  const modelTagParse = Tag.annotationToTag({
+    notes: model._modelDef.annotation.notes
+  }, { prefix: DOCS_M_TAG_PREFIX });
   const modelTags = modelTagParse.tag;
   const newModelDef = model._modelDef;
   let hasQuery = false;

--- a/scripts/run_code.ts
+++ b/scripts/run_code.ts
@@ -325,7 +325,7 @@ export async function runNotebookCode(
   // tags and not those from other cells, unsure if this is the right approach
   // long term, but it prevents `##(docs) hidden` from affecting subsequent cells
   const modelTagParse = Tag.annotationToTag({
-    notes: model._modelDef.annotation.notes
+    notes: model._modelDef?.annotation?.notes
   }, { prefix: DOCS_M_TAG_PREFIX });
   const modelTags = modelTagParse.tag;
   const newModelDef = model._modelDef;


### PR DESCRIPTION
Recent change to the way we handle model annotations for `extendModel` meant that `##(docs) hidden` was applying to all subsequent cells. This PR just removes the `inherits` section from the model annotation to prevent this, when calculating `##(docs)` model tags. I think this is an okay long term change, but not totally sure so I left a comment.