### PR TITLE
Update Malloy Documentation entries to include page title

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -69,8 +69,8 @@ for (const file of fs.readdirSync(LAYOUTS_PATH)) {
   }
 }
 
-Handlebars.registerHelper('ifeq', function(arg1, arg2, options) {
-  return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
+Handlebars.registerHelper("ifeq", function (arg1, arg2, options) {
+  return arg1 == arg2 ? options.fn(this) : options.inverse(this);
 });
 
 const WATCH_ENABLED = process.argv.includes("--watch");
@@ -92,7 +92,7 @@ async function compileDoc(
       | { type: "code"; text: string }
     )[];
   }[];
-  links: {link: string, style: "md" | "html", position: Position}[];
+  links: { link: string; style: "md" | "html"; position: Position }[];
   file: string;
   hashes: string[];
   renderedDocument: string;
@@ -108,7 +108,7 @@ async function compileDoc(
     const markdown = fs.readFileSync(file, "utf8");
     const template = Handlebars.compile(markdown);
     const templatedMarkdown = template({
-      ...DEFAULT_CONTEXT
+      ...DEFAULT_CONTEXT,
     });
     const {
       renderedDocument,
@@ -116,13 +116,11 @@ async function compileDoc(
       searchSegments,
       frontmatter,
       links,
-      hashes 
-    } = await renderDoc(
-      templatedMarkdown,
-      shortPath
-    );
-    const isBlog = shortPath.startsWith('/blog/');
-    const layoutName = frontmatter.layout ?? isBlog ? "blog.html" : "documentation.html";
+      hashes,
+    } = await renderDoc(templatedMarkdown, shortPath);
+    const isBlog = shortPath.startsWith("/blog/");
+    const layoutName =
+      frontmatter.layout ?? isBlog ? "blog.html" : "documentation.html";
     const nextBlog = nextPost(shortPath);
     const prevBlog = previoustPost(shortPath);
     const previewImage = getPreviewImage(shortPath);
@@ -164,11 +162,11 @@ async function compileDoc(
       links,
       file,
       hashes,
-      renderedDocument
+      renderedDocument,
     };
-  } catch(e) {
-    log("Error compiling:", 'error')
-    log(e)
+  } catch (e) {
+    log("Error compiling:", "error");
+    log(e);
   }
 }
 
@@ -193,28 +191,32 @@ interface BlogPostInfo {
 let BLOG_POSTS: BlogPostInfo[] = [];
 
 function buildBlogIndex() {
-  const blogPostsRaw = JSON.parse(fs.readFileSync(BLOG_LIST_PATH, "utf8")) as BlogPostInfoRaw[];
-  BLOG_POSTS = blogPostsRaw.map(post => ({ 
+  const blogPostsRaw = JSON.parse(
+    fs.readFileSync(BLOG_LIST_PATH, "utf8")
+  ) as BlogPostInfoRaw[];
+  BLOG_POSTS = blogPostsRaw.map((post) => ({
     ...post,
     published: new Date(
       parseInt(post.published.slice(0, 4)),
       parseInt(post.published.slice(5, 7)) - 1,
       parseInt(post.published.slice(8, 10))
-    )
+    ),
   }));
 
   BLOG_POSTS.sort((a, b) => b.published.getTime() - a.published.getTime());
 
-  const list = BLOG_POSTS.map(post => {
-    return `<a class="blog-post-link" href="${DEFAULT_CONTEXT.site.baseurl}/blog${post.path}">
+  const list = BLOG_POSTS.map((post) => {
+    return `<a class="blog-post-link" href="${
+      DEFAULT_CONTEXT.site.baseurl
+    }/blog${post.path}">
       <h1>${post.title}</h1>
-      ${post.subtitle ? `<div class="subtitle">${post.subtitle}</div>` : ''}
+      ${post.subtitle ? `<div class="subtitle">${post.subtitle}</div>` : ""}
       <div><i>${post.published.toLocaleDateString("en-US", {
         year: "numeric",
         month: "long",
         day: "numeric",
       })} by ${post.author}</i></div>
-    </a>`
+    </a>`;
   }).join("\n");
   const content = `<div class="document">${list}</div>`;
 
@@ -225,19 +227,25 @@ function buildBlogIndex() {
       content,
       title: "Malloy Blog",
       isBlogIndex: true,
-    }
+    },
   });
 
   fs.mkdirSync(path.join(OUT_PATH, "blog"), { recursive: true });
   fs.writeFileSync(path.join(OUT_PATH, "blog", "index.html"), compiledFile);
-  log("wrote /blog/index.html", 'info');
+  log("wrote /blog/index.html", "info");
 }
 
 function matchesPrefix(file: string) {
-  return !PATH_PREFIX || file.substring(DOCS_ROOT_PATH.length).startsWith(PATH_PREFIX);
+  return (
+    !PATH_PREFIX ||
+    file.substring(DOCS_ROOT_PATH.length).startsWith(PATH_PREFIX)
+  );
 }
 
-function rebuildSidebarAndFooters(): { toc: string; footers: Record<string, string> } {
+function rebuildSidebarAndFooters(): {
+  toc: string;
+  footers: Record<string, string>;
+} {
   try {
     const tableOfContents = readTableOfContents();
 
@@ -257,10 +265,10 @@ function rebuildSidebarAndFooters(): { toc: string; footers: Record<string, stri
     }
     log(`Files _includes/footers/** written.`);
     return { toc: renderedSidebar, footers };
-  } catch(e) {
-    log(`Error parsing JSON`, 'error');
-    log(e, 'error');
-    return { toc: "", footers: {}};
+  } catch (e) {
+    log(`Error parsing JSON`, "error");
+    log(e, "error");
+    return { toc: "", footers: {} };
   }
 }
 
@@ -302,9 +310,9 @@ function extractFrontmatter(contents: string) {
     const endFrontmatter = afterFirstLine.indexOf("\n---\n");
     const frontmatterRaw = afterFirstLine.slice(0, endFrontmatter + 1);
     const rest = afterFirstLine.slice(endFrontmatter + 4);
-    return {frontmatterRaw, rest};
+    return { frontmatterRaw, rest };
   } else {
-    return {frontmatterRaw: "", rest: contents};
+    return { frontmatterRaw: "", rest: contents };
   }
 }
 
@@ -316,7 +324,7 @@ function compileOtherFile(contents: string): string {
     ...DEFAULT_CONTEXT,
     page: {
       ...frontmatter,
-    }
+    },
   });
   if (frontmatter?.layout) {
     const template = LAYOUTS[frontmatter.layout];
@@ -325,7 +333,7 @@ function compileOtherFile(contents: string): string {
       page: {
         content: compiledContents,
         ...frontmatter,
-      }
+      },
     });
     return compiledFile;
   } else {
@@ -339,10 +347,8 @@ function handleStaticFile(file: string) {
     file.substring(DOCS_ROOT_PATH.length)
   );
   fs.mkdirSync(path.join(destination, ".."), { recursive: true });
-  if (
-    ["html", "js", "css"].some(ext => file.endsWith("." + ext))
-  ) {
-    const contents = fs.readFileSync(file, 'utf-8');
+  if (["html", "js", "css"].some((ext) => file.endsWith("." + ext))) {
+    const contents = fs.readFileSync(file, "utf-8");
     const compiledContents = compileOtherFile(contents);
     fs.writeFileSync(destination, compiledContents);
   } else {
@@ -351,30 +357,53 @@ function handleStaticFile(file: string) {
 }
 
 function validateLinks(
-  links: Record<string, {link: string, style: "md" | "html", position: Position}[]>, 
+  links: Record<
+    string,
+    { link: string; style: "md" | "html"; position: Position }[]
+  >,
   docs: string[],
   hashes?: Record<string, string[]>
 ): DocsError[] {
   const linkErrors: DocsError[] = [];
-  const docsRootedPaths = docs.map(f => f.substring(DOCS_ROOT_PATH.length));
-  function validateHash(origFile: string, origLink: string, file: string, hash: string, position: Position) {
+  const docsRootedPaths = docs.map((f) => f.substring(DOCS_ROOT_PATH.length));
+  function validateHash(
+    origFile: string,
+    origLink: string,
+    file: string,
+    hash: string,
+    position: Position
+  ) {
     if (hashes === undefined) return;
     const hashesForFile = hashes[file];
     if (!hashesForFile || !hashesForFile.includes(hash.slice(1))) {
       linkErrors.push({
         path: origFile.substring(DOCS_ROOT_PATH.length),
-        message: `Link ${origLink} is invalid: hash ${hash} doesn't exist in doc ${file.substring(DOCS_ROOT_PATH.length)}`,
+        message: `Link ${origLink} is invalid: hash ${hash} doesn't exist in doc ${file.substring(
+          DOCS_ROOT_PATH.length
+        )}`,
         position,
       });
     }
   }
-  function checkLink(file: string, originalLink: string, style: "md" | "html", rootedLink: string, position: Position) {
-    const linkWithoutHash = rootedLink.replace(/#.*$/, '');
+  function checkLink(
+    file: string,
+    originalLink: string,
+    style: "md" | "html",
+    rootedLink: string,
+    position: Position
+  ) {
+    const linkWithoutHash = rootedLink.replace(/#.*$/, "");
     const hashMatch = rootedLink.match(/#.*$/);
     const hash = hashMatch ? hashMatch[0] : undefined;
-    const linkHasExtension = linkWithoutHash.endsWith(".html") || linkWithoutHash.endsWith(".malloynb");
-    const linkGuessNB = linkHasExtension ? linkWithoutHash : (linkWithoutHash + ".malloynb");
-    const linkWithoutExtension = linkWithoutHash.replace(/\.html$/, "").replace(/\.malloynb$/, "");
+    const linkHasExtension =
+      linkWithoutHash.endsWith(".html") ||
+      linkWithoutHash.endsWith(".malloynb");
+    const linkGuessNB = linkHasExtension
+      ? linkWithoutHash
+      : linkWithoutHash + ".malloynb";
+    const linkWithoutExtension = linkWithoutHash
+      .replace(/\.html$/, "")
+      .replace(/\.malloynb$/, "");
     const existsNB = docsRootedPaths.includes(linkGuessNB);
     const exists = existsNB;
     const linkWithExtension = linkWithoutExtension + ".malloynb";
@@ -384,20 +413,26 @@ function validateLinks(
         message: `Link '${originalLink}' is invalid.`,
         position,
       });
-    } else if (linkHasExtension && style === 'html') {
+    } else if (linkHasExtension && style === "html") {
       linkErrors.push({
         path: file.substring(DOCS_ROOT_PATH.length),
         message: `HTML Link '${originalLink}' should not end with file extension.`,
-        position
+        position,
       });
-    } else if (style === 'md' && !linkWithoutHash.endsWith(".malloynb")) {
+    } else if (style === "md" && !linkWithoutHash.endsWith(".malloynb")) {
       linkErrors.push({
         path: file.substring(DOCS_ROOT_PATH.length),
         message: `Markdown Link '${originalLink}' should end with .malloynb`,
-        position
+        position,
       });
     } else if (hash && hashes) {
-      validateHash(file, originalLink, path.join(DOCS_ROOT_PATH, linkWithExtension), hash, position);
+      validateHash(
+        file,
+        originalLink,
+        path.join(DOCS_ROOT_PATH, linkWithExtension),
+        hash,
+        position
+      );
     }
 
     // TODO check in section info
@@ -409,11 +444,11 @@ function validateLinks(
         continue;
       }
       if (link.link.startsWith("/")) {
-        if(!ABSOLUTE_LINK_EXCEPTIONS.includes(link.link)) {
+        if (!ABSOLUTE_LINK_EXCEPTIONS.includes(link.link)) {
           linkErrors.push({
             path: file.substring(DOCS_ROOT_PATH.length),
             message: `HTML Link '${link.link}' is invalid (absolute links can't be followed in dev environments)`,
-            position: link.position
+            position: link.position,
           });
         }
       } else if (link.link.startsWith("#")) {
@@ -421,7 +456,7 @@ function validateLinks(
           validateHash(file, link.link, file, link.link, link.position);
         }
       } else {
-        const resolvedLink = path.resolve(file, '..', link.link);
+        const resolvedLink = path.resolve(file, "..", link.link);
         const rootedLink = resolvedLink.substring(DOCS_ROOT_PATH.length);
         checkLink(file, link.link, link.style, rootedLink, link.position);
       }
@@ -431,18 +466,29 @@ function validateLinks(
 }
 
 function logError(error: DocsError) {
-  log(`Error in file ${error.path}:${error.position.start.line}:${error.position.start.column}: ${error.message}`, 'error');
+  log(
+    `Error in file ${error.path}:${error.position.start.line}:${error.position.start.column}: ${error.message}`,
+    "error"
+  );
 }
 
 function nextPost(blogShortPath: string) {
-  const current = BLOG_POSTS.findIndex(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length));
+  const current = BLOG_POSTS.findIndex(
+    (post) =>
+      post.path + "/index.malloynb" === blogShortPath.slice("/blog".length)
+  );
   if (current !== -1 && current - 1 >= 0) {
-    return `${DEFAULT_CONTEXT.site.baseurl}/blog/${BLOG_POSTS[current - 1].path}`;
+    return `${DEFAULT_CONTEXT.site.baseurl}/blog/${
+      BLOG_POSTS[current - 1].path
+    }`;
   }
 }
 
 function blogTitle(blogShortPath: string) {
-  const title = BLOG_POSTS.find(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length))?.title;
+  const title = BLOG_POSTS.find(
+    (post) =>
+      post.path + "/index.malloynb" === blogShortPath.slice("/blog".length)
+  )?.title;
   return title ? title : "Malloy Blog";
 }
 
@@ -461,18 +507,26 @@ function sectionTitle(pathToTitleMap: Map<string, string>, path: string) {
 }
 
 function getPreviewImage(blogShortPath: string) {
-  const current = BLOG_POSTS.findIndex(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length));
+  const current = BLOG_POSTS.findIndex(
+    (post) =>
+      post.path + "/index.malloynb" === blogShortPath.slice("/blog".length)
+  );
 
   if (current !== -1 && BLOG_POSTS[current].previewImage) {
-    const post_path = `${DEFAULT_CONTEXT.site.baseurl}/blog${BLOG_POSTS[current].path}`
-    return `${post_path}/${BLOG_POSTS[current].previewImage}`
+    const post_path = `${DEFAULT_CONTEXT.site.baseurl}/blog${BLOG_POSTS[current].path}`;
+    return `${post_path}/${BLOG_POSTS[current].previewImage}`;
   }
 }
 
 function previoustPost(blogShortPath: string) {
-  const current = BLOG_POSTS.findIndex(post => post.path + "/index.malloynb" === blogShortPath.slice("/blog".length));
+  const current = BLOG_POSTS.findIndex(
+    (post) =>
+      post.path + "/index.malloynb" === blogShortPath.slice("/blog".length)
+  );
   if (current !== -1 && current + 1 < BLOG_POSTS.length) {
-    return `${DEFAULT_CONTEXT.site.baseurl}/blog/${BLOG_POSTS[current + 1].path}`;
+    return `${DEFAULT_CONTEXT.site.baseurl}/blog/${
+      BLOG_POSTS[current + 1].path
+    }`;
   }
 }
 
@@ -489,7 +543,7 @@ function buildPathToTitleMap(
     if ((section as Section).items) {
       buildPathToTitleMap((section as Section).items, map);
     } else if ((section as SectionItem).link) {
-      map[(section as SectionItem).link] = section.title;
+      map.set((section as SectionItem).link, section.title);
     }
   }
 
@@ -513,9 +567,10 @@ function readTableOfContents() {
     handleStaticFile(file);
   }
   const startTime = performance.now();
-  const results = await Promise.all(allDocs.map(async f => {
-    const result = await compileDoc(f, pathToTitleMap, footers);
-    const linkErrors = validateLinks({ [f]: result.links}, allDocs);
+  const results = await Promise.all(
+    allDocs.map(async (f) => {
+      const result = await compileDoc(f, pathToTitleMap, footers);
+      const linkErrors = validateLinks({ [f]: result.links }, allDocs);
       for (const error of linkErrors) {
         logError(error);
       }
@@ -523,8 +578,12 @@ function readTableOfContents() {
     })
   );
   const snippetErrors = results.map(({ errors }) => errors).flat();
-  const allLinks = Object.fromEntries(results.map(({ links, file }) => [file, links]));
-  const allHashes = Object.fromEntries(results.map(({ file, hashes }) => [file, hashes]));
+  const allLinks = Object.fromEntries(
+    results.map(({ links, file }) => [file, links])
+  );
+  const allHashes = Object.fromEntries(
+    results.map(({ file, hashes }) => [file, hashes])
+  );
   const linkErrors = validateLinks(allLinks, allDocs, allHashes);
   const allSegments = results
     .map(({ searchSegments }) => searchSegments)
@@ -533,7 +592,10 @@ function readTableOfContents() {
   // TODO make this update in watch mode
   outputSearchSegmentsFile(allSegments);
   outputMalloyRender();
-  log(`All docs compiled in ${timeString(startTime, performance.now())}`, 'success');
+  log(
+    `All docs compiled in ${timeString(startTime, performance.now())}`,
+    "success"
+  );
   if (WATCH_ENABLED) {
     log(`\nWatching /documentation and /models for changes...`);
     watchDebouncedRecursive(DOCS_ROOT_PATH, (type, file) => {


### PR DESCRIPTION
Currently, every documentation page on the Malloy documentation site uses a title 'Malloy Documentation'. This makes tabs harder to identify and may cause issues in certain search and indexing tools.

Update the documentation page generator to include the page's title.
