### PR TITLE
Strip unused location fields from models

### DIFF
--- a/scripts/run_code.ts
+++ b/scripts/run_code.ts
@@ -246,6 +246,21 @@ export async function runCode(
   return renderResult(queryResult, dataStyles, options);
 }
 
+// Simple check to prevent dropping sources named "location"
+const isLocation = (value: unknown) => {
+  return value && typeof value === "object" && "url" in value;
+};
+
+const stripLocation = (modelDef: ModelDef): ModelDef => {
+  return JSON.parse(JSON.stringify(modelDef), (key, value) => {
+    if (key === "location" && isLocation(value)) {
+      return undefined;
+    } else {
+      return value;
+    }
+  });
+};
+
 async function renderResult(
   queryResult: Result,
   dataStyles: DataStyles,
@@ -256,9 +271,9 @@ async function renderResult(
   const resultContainerId = crypto.randomUUID();
   let htmlResult = "";
   if (isNextRenderer) {
-    const script = `
+    const script = /* javascript */ `
     (function() {
-      const modelDef = ${JSON.stringify(queryResult._modelDef)};
+      const modelDef = ${JSON.stringify(stripLocation(queryResult._modelDef))};
       const queryResult = ${JSON.stringify(queryResult._queryResult)};
       const element = document.getElementById("${resultContainerId}");
       const malloyRender = document.createElement("malloy-render");


### PR DESCRIPTION
Strip location fields out of models, since they aren't used and contribute substantially to the size of some pages. Ideally we'd de-dupe models, but this is a cheap and cheerful fix with substantial savings:

before:
```sh
% ls -al docs/documentation/language/aggregates.html
-rw-r--r--@ 1 scullin  staff  5502324 May  1 13:10 docs/documentation/language/aggregates.html
```
after
```sh
% ls -al docs/documentation/language/aggregates.html
-rw-r--r--@ 1 scullin  staff  3257585 May  1 13:03 docs/documentation/language/aggregates.html
```
Roughly 40% savings.