### PR TITLE
Reduce file sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@malloydata/render": "0.0.282",
         "@malloydata/syntax-highlight": "0.0.282",
         "@types/jsdom": "^20.0.0",
+        "@types/uglify-js": "^3.17.5",
         "concurrently": "^6.2.1",
         "fs-extra": "^10.1.0",
         "http-server": "^14.1.1",
@@ -33,6 +34,7 @@
         "remark-parse": "^10.0.1",
         "shiki": "^0.10.1",
         "tsx": "^4.20.3",
+        "uglify-js": "^3.19.3",
         "unified": "^10.1.2"
       },
       "engines": {
@@ -1041,6 +1043,16 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
+    },
+    "node_modules/@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -5922,10 +5934,11 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "optional": true,
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -7626,6 +7639,15 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
     },
     "@types/unist": {
       "version": "2.0.6",
@@ -11166,10 +11188,10 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "optional": true
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "devOptional": true
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@malloydata/render": "0.0.282",
     "@malloydata/syntax-highlight": "0.0.282",
     "@types/jsdom": "^20.0.0",
+    "@types/uglify-js": "^3.17.5",
     "concurrently": "^6.2.1",
     "fs-extra": "^10.1.0",
     "http-server": "^14.1.1",
@@ -46,6 +47,7 @@
     "remark-parse": "^10.0.1",
     "shiki": "^0.10.1",
     "tsx": "^4.20.3",
+    "uglify-js": "^3.19.3",
     "unified": "^10.1.2"
   },
   "dependencies": {

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -24,11 +24,8 @@
 import path from "path";
 import fs from "fs";
 import { performance } from "perf_hooks";
-import {
-  getRenderDocResultForRenderedDoc,
-  renderDoc,
-} from "./render_document.js";
-import { renderFooter, renderSidebar, Section, SectionItem } from "./page.js";
+import { getRenderDocResultForRenderedDoc, renderDoc } from "./render_document";
+import { renderFooter, renderSidebar, Section, SectionItem } from "./page";
 import {
   convertDocPathToHTML,
   isMalloyNB,
@@ -36,15 +33,15 @@ import {
   timeString,
   watchDebounced,
   watchDebouncedRecursive,
-} from "./utils.js";
-import { DEPENDENCIES } from "./run_code.js";
-import { log } from "./log.js";
+} from "./utils";
+import { DEPENDENCIES } from "./run_code";
+import { log } from "./log";
 import { exit } from "process";
 import Handlebars from "handlebars";
 import yaml from "yaml";
-import { DEFAULT_CONTEXT } from "./context.js";
-import { Position } from "./markdown_types.js";
-import { DocsError } from "./errors.js";
+import { DEFAULT_CONTEXT } from "./context";
+import { Position } from "./markdown_types";
+import { DocsError } from "./errors";
 
 const __dirname = path.resolve("./scripts/");
 
@@ -295,7 +292,7 @@ function outputSearchSegmentsFile(
     2
   )}`;
   fs.mkdirSync(JS_OUT_PATH, { recursive: true });
-  fs.writeFileSync(path.join(JS_OUT_PATH, "search_segments.js"), file);
+  fs.writeFileSync(path.join(JS_OUT_PATH, "search_segments"), file);
   log(`File js/generated/search_segments.js written.`);
 }
 

--- a/scripts/run_code.ts
+++ b/scripts/run_code.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import Uglify from "uglify-js";
 import { DataStyles, HTMLView } from "@malloydata/render";
 import {
   Runtime,
@@ -34,15 +35,13 @@ import { DuckDBConnection } from "@malloydata/db-duckdb";
 import path from "path";
 import { promises as fs } from "fs";
 import { performance } from "perf_hooks";
-import { timeString } from "./utils.js";
-import { log } from "./log.js";
+import { timeString } from "./utils";
+import { log } from "./log";
 import { JSDOM } from "jsdom";
-import { highlight } from "./highlighter.js";
+import { highlight } from "./highlighter";
 
-const __dirname = path.resolve("./scripts/index.ts");
-
-const MODELS_PATH = path.join(__dirname, "../../models");
-const DOCS_ROOT_PATH = path.join(__dirname, "../../src");
+const MODELS_PATH = path.resolve("./models");
+const DOCS_ROOT_PATH = path.resolve("./src");
 
 export const DEPENDENCIES = new Map<string, string[]>();
 
@@ -236,7 +235,7 @@ async function renderResult(
       malloyRender.queryResult = queryResult;
       element.appendChild(malloyRender);
     })();`;
-    htmlResult = `<script>${script}</script>`;
+    htmlResult += `<script>${Uglify.minify(script).code}</script>`;
   } else {
     const document = new JSDOM().window.document;
     const element = await new HTMLView(document).render(queryResult, {

--- a/src/documentation/language/functions.malloynb
+++ b/src/documentation/language/functions.malloynb
@@ -10,6 +10,7 @@ For quick function lookup, see the [alphebetized table of all available function
 Note: the behavior of functions changed in v0.0.39. For more information, see [a description of that change](./new_functions.malloynb).
 >>>malloy
 ##(docs) hidden
+## renderer_legacy
 import "flights.malloy"
 
 source: empty is duckdb.sql("""


### PR DESCRIPTION
Various efforts and cleanup with the goal of getting functions.html < 14M. Final solution was to switch to legacy renderer for functions.malloynb since even with aggressive minification our result ModelDefs add up with as many tables as get rendered in that file.

When we retire the legacy renderer we will need to invent a simple static table renderer just for this page.