### PR TITLE
docs: tighten securityPolicy section and note CWD path resolution

### DIFF
--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -85,17 +85,15 @@ malloy-config-local.json
 
 #### Restricted execution
 
-For untrusted code, Malloy offers a single `securityPolicy` property with three levels:
+`securityPolicy` has three levels:
 
-- `"none"` — no security policy applied. Ordinary DuckDB behavior. This is the default.
-- `"local"` — no network access. DuckDB cannot reach the network, but local filesystem access is not sandboxed to specific directories. Appropriate when the host already provides filesystem isolation (e.g. a container boundary).
-- `"sandboxed"` — no network access AND filesystem confined to `allowedDirectories` (defaults to `workingDirectory`). The reviewed strict recipe for untrusted Malloy. POSIX only.
+- `"none"` — default. Ordinary DuckDB behavior.
+- `"local"` — disables network access.
+- `"sandboxed"` — `"local"` plus a DuckDB directory allowlist (`allowedDirectories`, defaulting to `workingDirectory`). POSIX only.
 
 Both `"local"` and `"sandboxed"` force `enableExternalAccess=false`, block `httpfs` and `INSTALL`, reject remote `databasePath` and `motherDuckToken`, lock configuration, and encrypt temp files. `"sandboxed"` additionally enforces directory containment and derives a safe `tempDirectory` inside the sandbox.
 
-DuckDB's `enable_external_access` is a single toggle that gates both filesystem reach and network reach. `allowed_directories` only takes effect when external access is disabled. This is why `securityPolicy` is a single axis — the underlying DuckDB mechanism does not support independent filesystem and network control.
-
-The reviewed strict recipe:
+Under `"sandboxed"`, DuckDB resolves relative file paths against the host process working directory (`getcwd()`), not against Malloy's `workingDirectory`. Relative-path reads only succeed when the process CWD is inside an allowed directory.
 
 ```json
 {
@@ -110,7 +108,7 @@ The reviewed strict recipe:
 }
 ```
 
-Policies set a floor, not a ceiling. `allowedDirectories` and `tempDirectory` can be set explicitly to customize the sandbox. Other policy-controlled settings accept matching values but reject weaker ones — connection creation fails closed. `setupSQL`, `additionalExtensions`, `motherDuckToken`, and remote `databasePath` are incompatible with any restricted policy; to use them, keep `securityPolicy` at `"none"` and configure DuckDB directly. Policies do not set resource limits — configure `threads`, `memoryLimit`, timeouts, and host quotas separately.
+Policies set a floor, not a ceiling. `allowedDirectories` and `tempDirectory` can be set explicitly. Other policy-controlled settings accept matching values but reject weaker ones — connection creation fails closed. `setupSQL`, `additionalExtensions`, `motherDuckToken`, and remote `databasePath` are incompatible with any restricted policy. Policies do not set resource limits — configure `threads`, `memoryLimit`, and timeouts separately.
 
 ### `bigquery` — Google BigQuery
 


### PR DESCRIPTION
## Summary
- Trim the restricted-execution prose in the DuckDB `securityPolicy` section
- Add a note that under `"sandboxed"`, DuckDB resolves relative file paths against the host process CWD (`getcwd()`), not Malloy's `workingDirectory`

## Test plan
- [x] Render the setup config doc and confirm the Restricted execution section reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)