### PR TITLE
fix: derive heading anchors from plain text, not rendered HTML

### DIFF
--- a/scripts/render_document.ts
+++ b/scripts/render_document.ts
@@ -39,6 +39,20 @@ import {
 import { DocumentPosition, DocumentRange, ModelDef } from "@malloydata/malloy";
 import { DocsError } from "./errors.js";
 
+function plainTextFromMarkdown(nodes: Markdown[]): string {
+  return nodes
+    .map((node) => {
+      if ("value" in node && typeof node.value === "string") {
+        return node.type === "html" ? "" : node.value;
+      }
+      if ("children" in node && Array.isArray(node.children)) {
+        return plainTextFromMarkdown(node.children as Markdown[]);
+      }
+      return "";
+    })
+    .join("");
+}
+
 /*
  * A Renderer is capable of converting a parsed `Markdown` document into HTML,
  * given that it exists at a given `path`.
@@ -202,7 +216,7 @@ class Renderer {
   protected async heading(content: Markdown[], level: 1 | 2 | 3 | 4 | 5 | 6) {
     const text = await this.children(content);
     this.registerTitle(text, level);
-    const escapedText = hashForHeading(text);
+    const escapedText = hashForHeading(plainTextFromMarkdown(content));
     this.hashes.push(escapedText);
     // TODO handle ambiguous hashes?
 


### PR DESCRIPTION
## Summary

Headings containing inline code were producing anchor ids that included the syntax-highlighter's full HTML markup. Example before:

```
#array-givens-and-code-class-language-malloy-style-background-color-fbfbfb-span-class-line-span-style-color-001080-in-span-span-code-
```

`render_document.ts:heading()` was hashing the rendered HTML version of the heading content. This change walks the Markdown AST to extract plain text first, then slugs that. The displayed heading still uses the full rendered HTML — only the anchor `id` (and matching `href`) use the plain-text slug.

After the fix, the example heading becomes `#array-givens-and-in`.

## Impact on existing links

I grep'd every authored `(#anchor)` link in `src/`: all of them already use clean slugs (`#finalizing-givens-at-the-runtime`, `#accepted-js-shapes`, etc.). They were *broken* under the old generator whenever they pointed at a header containing inline code; this change makes them resolve correctly. No source-side fixups are needed.

External bookmarks or third-party links pointing at the old junk anchors would no longer resolve, but those URLs weren't usable to begin with — they were never the canonical form an author would have written.

## Test plan
- [ ] `npm run build` succeeds.
- [ ] On the givens experiment page, `#array-givens-and-in` resolves to the heading. (Verified locally.)
- [ ] Spot-check a few other pages with inline-code headers — e.g. `setup/config.malloynb`, `experiments/givens.malloynb` — and confirm their anchors look clean and in-page links work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)