### PR TITLE
docs: model annotations and their behavior across import

### DIFF
--- a/src/documentation/experiments/experiments.malloynb
+++ b/src/documentation/experiments/experiments.malloynb
@@ -16,3 +16,7 @@ Below is a list of currently running experiments and how to turn them on.
 * `##! experimental.persistence` - [Persist sources as tables with the CLI builder](persistence.malloynb)
 * `##! experimental.virtual_source` - [Declare types and define virtual sources with no underlying table](virtual_sources.malloynb)
 * `##! experimental.givens` - [Model-level parameters supplied at run time](givens.malloynb)
+
+## Where to put a compiler flag
+
+Compiler flags are **per-file**. If a file uses an experimental feature, put the `##!` annotations at the top of that file.

--- a/src/documentation/language/imports.malloynb
+++ b/src/documentation/language/imports.malloynb
@@ -34,6 +34,10 @@ run: airports -> { aggregate: airport_count is count() }
 run: spaceports -> { aggregate: spaceport_count is count() }
 >>>markdown
 
+## Imported model annotations
+
+Importing a file, either entirely or using a selective `import { .. }`, also brings in that file's [`##` model annotations](tags.malloynb#model-annotations).
+
 ## Exports
 
 By default, every `source:`, `query:`, `given:`, and `type:` declared in a file is exported &mdash; that is, visible to anyone who imports the file. If you'd rather keep some definitions local (for example, helper sources used only as scaffolding for the things you actually publish), add an `export { ... }` statement listing only the names you want to expose:

--- a/src/documentation/language/tags.malloynb
+++ b/src/documentation/language/tags.malloynb
@@ -53,6 +53,28 @@ measure:
   min_x is min(x)
 ```
 
+## Model annotations
+
+An annotation written with `##` belongs to the *model* — the whole file — rather than to the object declared below it. Like every annotation, it is just text: the compiler stores it and hands it back, and what it means is up to the application that reads it.
+
+Model annotations travel with a file's contents. When you `import` a file, its model annotations come along, just as its sources and queries do — even through a [selective import](imports.malloynb#selective-imports). When retrieving annotations, imported annotations are returned first:
+
+```malloy
+// lib.malloy
+##(myApp) appTheme=dark
+source: airports is duckdb.table('airports.parquet')
+```
+
+```malloy
+// report.malloy
+import "lib.malloy"
+##(myApp) appTheme=light
+// this model's (myApp) annotations, in order:
+//   appTheme=dark   (from lib.malloy)
+//   appTheme=light  (from this file)
+```
+
+
 ## Prefix and route
 
 Everything from the marker (`#`/`##`/`#|`/`##|`) up to the first whitespace is the annotation's **prefix**. The prefix resolves to a **route** — a namespace key. The compiler validates the *shape* of the prefix and routes the annotation; it never parses what comes after.


### PR DESCRIPTION
With https://github.com/malloydata/malloy/pull/2863 model annotations are now a more polished feature.  Update docs.