### PR TITLE
Note that a tag's { } block binds to the last dotted segment

### DIFF
--- a/src/documentation/visualizations/bar_charts.malloynb
+++ b/src/documentation/visualizations/bar_charts.malloynb
@@ -22,6 +22,8 @@ Malloy can create simple bar charts and bar charts with series breakdowns, eithe
 | `.title` | Chart title | `# bar_chart { title='My Title' }` |
 | `.subtitle` | Chart subtitle | `# bar_chart { subtitle='Details' }` |
 
+A `{ }` block attaches to the last segment of a dotted path, so `# bar_chart.stack { y=total_sales }` sets `y` on `stack` instead of on `bar_chart`, and the chart never reads it. To set both, put them in a single block: `# bar_chart { stack y=total_sales }`. See [Tags](../language/tags.malloynb) for the full property syntax.
+
 The examples below all use the following semantic model.
 >>>malloy
 source: flights is duckdb.table('../data/flights.parquet') extend {

--- a/src/documentation/visualizations/numbers.malloynb
+++ b/src/documentation/visualizations/numbers.malloynb
@@ -220,6 +220,8 @@ The `# duration` renderer interprets a value as a number of seconds and renders 
 | `.terse` | Abbreviated units (ns, µs, ms, s, m, h, d) |
 | `.number` | SSF format for numeric parts: `# duration { number="0.0" }` |
 
+A `{ }` block attaches to the last segment of a dotted path, so `# duration.terse { number="0.0" }` sets `number` on `terse` instead of on `duration`. To set both, put them in a single block: `# duration { terse number="0.0" }`.
+
 >>>malloy
 #(docs) size=small limit=5000
 run: flights -> {


### PR DESCRIPTION
## What

`# bar_chart.stack { y=total_sales }` parses cleanly, sets `y` on `stack` where nothing reads it, and renders a chart that silently ignores the field you asked for. A user hit this in production last week and had to open the network tab to find out why their chart was empty.

The docs aren't wrong about any of this, which is worth saying plainly: there's no example of that form anywhere, and `bar_charts.malloynb` correctly shows `# bar_chart.stack` bare. The gap is that nothing states the binding rule where a chart author would meet it.

Two properties tables invite the mistake by naming every property in dotted form and then showing brace-form examples a few rows down, so welding the two reads as the natural way to set both at once:

- `bar_charts.malloynb`: `.stack` → `# bar_chart.stack` at :10, and `.y` → `# bar_chart { y=total_sales }` three rows later. This is the one the user hit.
- `numbers.malloynb`: the `# duration` table puts `.terse` directly above `.number` → `# duration { number="0.0" }`, adjacent lines.

This adds one line to each.

## Why not just link to the tag reference

`language/tags.malloynb` does document the shape, under advanced property syntax, but only for `tName.p1=value { pp1=v1 pp2=v2 }` — the form *with* a value. The trap is the value-less form, `tName.p1 { ... }`, which isn't shown. It also never says "last segment", and it's in the language reference rather than where someone reading a chart's properties is looking. So the note states the rule at the point of confusion and links out for the rest.

## Verified

Both forms run through the real `@malloydata/malloy-tag` parser, because "looks right" isn't enough here:

| form | resulting tag tree |
|---|---|
| `# bar_chart.stack { y=total_sales }` | `bar_chart.stack.y` — y buried under stack |
| `# bar_chart { stack y=total_sales }` | `bar_chart.stack` + `bar_chart.y` |
| `# duration.terse { number="0.0" }` | `duration.terse.number` — number buried under terse |
| `# duration { terse number="0.0" }` | `duration.terse` + `duration.number` |

Both trap forms parse without error, which is exactly what makes them a trap. The fix form's tree is the exact union of `# duration.terse` and `# duration { number="0.0" }`, so the two are provably equivalent rather than plausibly so.

`npm run build-prod` passes locally.

## Scope

Only tables that pair a bare dotted example with a brace example for the same tag can produce the inference, which is these two. `charts_line_chart.malloynb` is all-brace with no bare-dotted example. `overview.malloynb` lists `.stack` and `.terse`, but its Key Properties column is a name list rather than usage examples, and its neighbouring brace examples are different tag roots, so there's nothing to weld — it links here anyway.
