### PR TITLE
docs(publishing): scaffold a package with `npm create malloy-package`

### DIFF
--- a/src/documentation/user_guides/publishing/publishing.malloynb
+++ b/src/documentation/user_guides/publishing/publishing.malloynb
@@ -16,7 +16,24 @@ Once published, your models can be accessed via:
 
 ### 1. Create a Package
 
-A package is a directory with your models and a manifest:
+The fastest way is to let Publisher scaffold one:
+
+```bash
+npm create malloy-package my-analytics
+```
+
+That writes the package and a starter model, registers it in `publisher.config.json` so the server actually serves it, and sets up the workspace around it: a start script, an MCP config, agent instructions, and the Malloy agent skills as files an AI assistant can read. To build the starter model over a CSV or Parquet file of your own, pass it in:
+
+```bash
+npm create malloy-package my-analytics -- --data ./orders.csv   # npm create needs the --
+npx create-malloy-package my-analytics --data ./orders.csv      # npx does not, and rejects it
+```
+
+The two entry points differ in one way that matters. `npm create` reads anything before the `--` as one of its own options, so the separator is required there. `npx` passes flags through untouched, and a `--` would reach the tool as an extra argument.
+
+Both require Node on your machine.
+
+If you would rather assemble the package yourself, it is just a directory with your models and a manifest:
 
 ```
 my-analytics/

--- a/src/documentation/user_guides/publishing/publishing.malloynb
+++ b/src/documentation/user_guides/publishing/publishing.malloynb
@@ -22,7 +22,7 @@ The fastest way is to let Publisher scaffold one:
 npm create malloy-package my-analytics
 ```
 
-That writes the package and a starter model, registers it in `publisher.config.json` so the server actually serves it, and sets up the workspace around it: a start script, an MCP config, agent instructions, and the Malloy agent skills as files an AI assistant can read. To build the starter model over a CSV or Parquet file of your own, pass it in:
+That writes the package and a starter model, registers it in `publisher.config.json` so the server actually serves it, and sets up the workspace around it: a start script, an MCP config, agent instructions, and the Malloy agent skills as files an AI assistant can read. Seed the starter model from a local file with `--data` (CSV, Parquet, or Excel):
 
 ```bash
 npm create malloy-package my-analytics -- --data ./orders.csv   # npm create needs the --
@@ -31,7 +31,7 @@ npx create-malloy-package my-analytics --data ./orders.csv      # npx does not, 
 
 The two entry points differ in one way that matters. `npm create` reads anything before the `--` as one of its own options, so the separator is required there. `npx` passes flags through untouched, and a `--` would reach the tool as an extra argument.
 
-Both require Node on your machine.
+A package is just Malloy, so it is not limited to a local file: point its model at a database connection your config defines and the same workspace serves a warehouse. Both entry points require Node on your machine.
 
 If you would rather assemble the package yourself, it is just a directory with your models and a manifest:
 


### PR DESCRIPTION
The Quick Start opened by asking the reader to hand-build a package directory and a manifest. The scaffolder does that for them, registers the package so the server actually serves it, and sets up the workspace around it, so it belongs first, with the by-hand layout kept underneath for anyone who wants it.

Both the `npm create` and `npx` forms are shown, because they parse options differently and getting it wrong fails in a way a reader cannot reason about: `npm create` treats anything before a `--` as one of its own options, so the separator is required, while `npx` forwards flags untouched and counts a `--` as an extra argument. Verified against both entry points rather than assumed.

Both require Node, which is worth stating plainly on a page a non-developer may land on.

The framing points at "your own data" rather than a specific file type: `--data` seeds the starter model from a local CSV, Parquet, or Excel file, and a note says a package's model can also point at a database connection the config defines, so the same workspace serves a warehouse. This matches the same rewording on the Publisher README (malloydata/publisher#910).

The merge-order caveat this PR originally carried is now cleared: `create-malloy-package` is published to npm (as is `@malloy-publisher/skills`, which it installs), and I verified the command scaffolds a real package and copies the skills end to end from the live registry.
