### PR TITLE
docs(publishing): use the scoped npm create command

### DIFF
--- a/src/documentation/user_guides/publishing/publishing.malloynb
+++ b/src/documentation/user_guides/publishing/publishing.malloynb
@@ -19,14 +19,14 @@ Once published, your models can be accessed via:
 The fastest way is to let Publisher scaffold one:
 
 ```bash
-npm create malloy-package my-analytics
+npm create @malloy-publisher/malloy-package my-analytics
 ```
 
 That writes the package and a starter model, registers it in `publisher.config.json` so the server actually serves it, and sets up the workspace around it: a start script, an MCP config, agent instructions, and the Malloy agent skills as files an AI assistant can read. Seed the starter model from a local file with `--data` (CSV, Parquet, or Excel):
 
 ```bash
-npm create malloy-package my-analytics -- --data ./orders.csv   # npm create needs the --
-npx create-malloy-package my-analytics --data ./orders.csv      # npx does not, and rejects it
+npm create @malloy-publisher/malloy-package my-analytics -- --data ./orders.csv   # npm create needs the --
+npx @malloy-publisher/create-malloy-package my-analytics --data ./orders.csv      # npx does not, and rejects it
 ```
 
 The two entry points differ in one way that matters. `npm create` reads anything before the `--` as one of its own options, so the separator is required there. `npx` passes flags through untouched, and a `--` would reach the tool as an extra argument.


### PR DESCRIPTION
Follow-up to #332. The scaffolder was republished under the org scope as `@malloy-publisher/create-malloy-package`, and the old unscoped `create-malloy-package` was unpublished, so the quick start now needs the scoped command:

- `npm create @malloy-publisher/malloy-package <name>` (was `npm create malloy-package`)
- `npx @malloy-publisher/create-malloy-package <name>` (was `npx create-malloy-package`)

The unscoped command 404s now, and npm blocks re-publishing an unpublished name for 24 hours, so this is the only way to make the page's command work again. Matches the same swap on the Publisher README (malloydata/publisher#910). Three lines, markdown only.
