### PR TITLE
docs(config): clarify BigQuery timeoutMs semantics

### DIFF
--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -148,7 +148,7 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `serviceAccountKey` | json | Service account key as a JSON object (alternative to file path) |
 | `location` | string | Dataset location |
 | `maximumBytesBilled` | string | Byte billing cap |
-| `timeoutMs` | string | Total query timeout in ms, bounding both the BigQuery job and the results-fetch polling. Defaults to 600000 (10 min); an unset, blank, non-numeric, or `0` value falls back to that default. |
+| `timeoutMs` | string | Total query timeout in ms, bounding both the BigQuery job and the results-fetch polling. Defaults to 600000 (10 min); an unset, blank, non-numeric, zero, or negative value falls back to that default. |
 | `billingProjectId` | string | Billing project (if different) |
 | `setupSQL` | text | Connection setup SQL ([see below](#setup-sql)) |
 

--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -148,7 +148,7 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `serviceAccountKey` | json | Service account key as a JSON object (alternative to file path) |
 | `location` | string | Dataset location |
 | `maximumBytesBilled` | string | Byte billing cap |
-| `timeoutMs` | string | Total query timeout in ms, bounding both the BigQuery job and the results-fetch polling. Defaults to 600000 (10 min); `0` means no client-side timeout (let BigQuery decide). |
+| `timeoutMs` | string | Total query timeout in ms, bounding both the BigQuery job and the results-fetch polling. Defaults to 600000 (10 min); an unset, blank, non-numeric, or `0` value falls back to that default. |
 | `billingProjectId` | string | Billing project (if different) |
 | `setupSQL` | text | Connection setup SQL ([see below](#setup-sql)) |
 

--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -148,7 +148,7 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `serviceAccountKey` | json | Service account key as a JSON object (alternative to file path) |
 | `location` | string | Dataset location |
 | `maximumBytesBilled` | string | Byte billing cap |
-| `timeoutMs` | string | Query timeout in ms |
+| `timeoutMs` | string | Total query timeout in ms, bounding both the BigQuery job and the results-fetch polling. Defaults to 600000 (10 min); `0` means no client-side timeout (let BigQuery decide). |
 | `billingProjectId` | string | Billing project (if different) |
 | `setupSQL` | text | Connection setup SQL ([see below](#setup-sql)) |
 


### PR DESCRIPTION
Companion to malloydata/malloy#3010, which changes what the BigQuery connection
`timeoutMs` bounds.

Before that PR, `timeoutMs` only bounded `jobTimeoutMs`; the results-fetch wait
was hard-capped near six minutes no matter what was configured. After it,
`timeoutMs` bounds the total wait (the BigQuery job and the results-fetch
polling), so the existing "Query timeout in ms" description is arguably only
becoming fully true now.

This updates the BigQuery `timeoutMs` row to spell out:

- what it bounds now (the job plus results polling)
- the default (600000, 10 min)
- that an unset, blank, non-numeric, zero, or negative value falls back to that default

Per the cross-repo checklist in `malloy` at
`packages/malloy/src/connection/CONTEXT.md`.
