### PR TITLE
docs(config): clarify Snowflake timeoutMs semantics

### DIFF
--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -222,7 +222,7 @@ The `ssl` property accepts a JSON object passed directly to the underlying [node
 | `privateKeyPath` | file | Path to private key (.pem/.key) |
 | `privateKey` | password | Private key PEM string (alternative to file path) |
 | `privateKeyPass` | password | Private key passphrase |
-| `timeoutMs` | number | Per-statement query timeout in ms. Defaults to 600000 (10 min); an unset, blank, non-numeric, or `0` value falls back to that default. |
+| `timeoutMs` | number | Per-statement query timeout in ms. Defaults to 600000 (10 min); an unset, blank, non-numeric, zero, or negative value falls back to that default. |
 | `schemaSampleTimeoutMs` | number | Variant schema sample timeout in ms (default 15000) |
 | `schemaSampleRowLimit` | number | Row limit for variant schema sample (default 1000) |
 | `schemaSampleFullScanMaxBytes` | number | Tables at or below this byte size are full-scanned instead of sampled |

--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -222,7 +222,7 @@ The `ssl` property accepts a JSON object passed directly to the underlying [node
 | `privateKeyPath` | file | Path to private key (.pem/.key) |
 | `privateKey` | password | Private key PEM string (alternative to file path) |
 | `privateKeyPass` | password | Private key passphrase |
-| `timeoutMs` | number | Query timeout in ms |
+| `timeoutMs` | number | Per-statement query timeout in ms. Defaults to 600000 (10 min); an unset, blank, non-numeric, or `0` value falls back to that default. |
 | `schemaSampleTimeoutMs` | number | Variant schema sample timeout in ms (default 15000) |
 | `schemaSampleRowLimit` | number | Row limit for variant schema sample (default 1000) |
 | `schemaSampleFullScanMaxBytes` | number | Tables at or below this byte size are full-scanned instead of sampled |


### PR DESCRIPTION
Companion to malloydata/malloy#3022, which makes the Snowflake connector's
`timeoutMs` consistent with BigQuery: a configured `0` (or a blank / non-numeric
value) now falls back to the default instead of meaning "wait forever".

This updates the Snowflake `timeoutMs` row to spell out:

- the default (600000, 10 min)
- that it is a per-statement client-side timeout
- that an unset, blank, non-numeric, zero, or negative value falls back to that default

Per the cross-repo checklist in `malloy` at
`packages/malloy/src/connection/CONTEXT.md`.
