### PR TITLE
docs(config): document the Databricks timeoutMs setting

### DIFF
--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -164,6 +164,7 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `defaultCatalog` | string | Default Unity Catalog name |
 | `defaultSchema` | string | Default schema name |
 | `setupSQL` | text | Connection setup SQL ([see below](#setup-sql)) |
+| `timeoutMs` | number | Client-side query timeout in ms; the query is cancelled if it runs longer. Defaults to 600000 (10 min); an unset, blank, non-numeric, zero, or negative value falls back to that default. |
 
 Authentication: provide either `token` or the `oauthClientId` + `oauthClientSecret` pair.
 


### PR DESCRIPTION
Companion to malloydata/malloy#3024, which adds a `timeoutMs` setting to the
Databricks connector (it had no query timeout before).

This adds a `timeoutMs` row to the Databricks connection table:

- what it is (a client-side query timeout in ms; the query is cancelled if it
  runs longer)
- the default (600000, 10 min)
- that an unset, blank, non-numeric, zero, or negative value falls back to that
  default

Per the cross-repo checklist in `malloy` at
`packages/malloy/src/connection/CONTEXT.md`.
