### PR TITLE
docs(config): supplying a BigQuery service account key from the environment

### DIFF
--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -181,8 +181,6 @@ The property also accepts the key base64-encoded, which is one unquoted token an
 export BIGQUERY_CREDENTIALS_JSON="$(base64 < service-account-key.json | tr -d '\n')"
 ```
 
-No flag distinguishes the two — the encoding is detected, since JSON always begins with `{` and `{` is not a base64 character. Surrounding whitespace is ignored, so a trailing newline from `$(cat …)` or a here-doc is harmless.
-
 Note that `serviceAccountKey` — the `json`-typed property — **cannot** take an environment variable reference. Like every `json` property, it treats `{"env": "..."}` as literal data, so that object itself becomes the credentials and BigQuery rejects it with `The incoming JSON object does not contain a client_email field`. Use `serviceAccountKeyJson` instead. If both are set, `serviceAccountKey` wins.
 
 ### `databricks` — Databricks
@@ -375,6 +373,4 @@ Any property value can be replaced with an environment variable reference. This 
 The `{"env": "VAR_NAME"}` syntax looks up the value from the named environment variable at connection time. If the variable is not set, the field is omitted and the connection proceeds without it.
 
 You can also provide a plain string value directly — this is useful for testing but not recommended for shared or committed config files.
-
-**One exception: `json` properties.** Properties whose type is `json` — `serviceAccountKey`, `ssl`, `session`, `extraCredential`, `extraHeaders` — hold structured data, and they take that data literally. A `{"env": "..."}` written inside one is not resolved; it is passed along to the driver as the object it looks like, which usually surfaces later as a confusing error from the driver rather than as a missing-variable message. Where a secret needs to come from the environment, use the string-typed property meant for it (for BigQuery, [`serviceAccountKeyJson`](#bigquery-google-bigquery)).
 

--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -146,11 +146,43 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `projectId` | string | GCP project ID |
 | `serviceAccountKeyPath` | file | Path to service account JSON key |
 | `serviceAccountKey` | json | Service account key as a JSON object (alternative to file path) |
+| `serviceAccountKeyJson` | secret | Service account key as a JSON **string** |
+| `serviceAccountKeyJsonBase64` | secret | Service account key as base64-encoded JSON |
 | `location` | string | Dataset location |
 | `maximumBytesBilled` | string | Byte billing cap |
 | `timeoutMs` | string | Query timeout in ms |
 | `billingProjectId` | string | Billing project (if different) |
 | `setupSQL` | text | Connection setup SQL ([see below](#setup-sql)) |
+
+With no key configured at all, the connection uses [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) — the usual choice for local development, where `gcloud auth application-default login` has already run.
+
+**Supplying the key from the environment.** On a server the key normally arrives as an environment variable rather than as a file on disk. Use `serviceAccountKeyJson`, which holds the entire key file as a string:
+
+```json
+{
+  "connections": {
+    "my_bigquery": {
+      "is": "bigquery",
+      "projectId": "my-project",
+      "serviceAccountKeyJson": {"env": "BIGQUERY_CREDENTIALS_JSON"}
+    }
+  }
+}
+```
+
+Set the variable to the key file's contents on a single line — the key's own `\n` escapes are preserved by JSON, and quoting the value keeps the shell out of it:
+
+```bash
+export BIGQUERY_CREDENTIALS_JSON="$(jq -c . service-account-key.json)"
+```
+
+`serviceAccountKeyJsonBase64` takes the same key base64-encoded, for pipelines and secret stores that mangle the quoting or the embedded newlines of raw JSON:
+
+```bash
+export BIGQUERY_CREDENTIALS_JSON_B64="$(base64 < service-account-key.json | tr -d '\n')"
+```
+
+Note that `serviceAccountKey` — the `json`-typed property — **cannot** take an environment variable reference. Like every `json` property, it treats `{"env": "..."}` as literal data, so that object itself becomes the credentials and BigQuery rejects it with `The incoming JSON object does not contain a client_email field`. Use one of the two `secret` properties above instead. If several are set, the order of precedence is `serviceAccountKey`, `serviceAccountKeyJson`, `serviceAccountKeyJsonBase64`.
 
 ### `databricks` — Databricks
 
@@ -342,4 +374,6 @@ Any property value can be replaced with an environment variable reference. This 
 The `{"env": "VAR_NAME"}` syntax looks up the value from the named environment variable at connection time. If the variable is not set, the field is omitted and the connection proceeds without it.
 
 You can also provide a plain string value directly — this is useful for testing but not recommended for shared or committed config files.
+
+**One exception: `json` properties.** Properties whose type is `json` — `serviceAccountKey`, `ssl`, `session`, `extraCredential`, `extraHeaders` — hold structured data, and they take that data literally. A `{"env": "..."}` written inside one is not resolved; it is passed along to the driver as the object it looks like, which usually surfaces later as a confusing error from the driver rather than as a missing-variable message. Where a secret needs to come from the environment, use the string-typed property meant for it (for BigQuery, [`serviceAccountKeyJson`](#bigquery-google-bigquery)).
 

--- a/src/documentation/setup/config.malloynb
+++ b/src/documentation/setup/config.malloynb
@@ -146,8 +146,7 @@ Malloy exposes two parameters that let you choose how a connection participates 
 | `projectId` | string | GCP project ID |
 | `serviceAccountKeyPath` | file | Path to service account JSON key |
 | `serviceAccountKey` | json | Service account key as a JSON object (alternative to file path) |
-| `serviceAccountKeyJson` | secret | Service account key as a JSON **string** |
-| `serviceAccountKeyJsonBase64` | secret | Service account key as base64-encoded JSON |
+| `serviceAccountKeyJson` | secret | Service account key as a **string** — JSON or base64-encoded JSON |
 | `location` | string | Dataset location |
 | `maximumBytesBilled` | string | Byte billing cap |
 | `timeoutMs` | string | Query timeout in ms |
@@ -170,19 +169,21 @@ With no key configured at all, the connection uses [application default credenti
 }
 ```
 
-Set the variable to the key file's contents on a single line — the key's own `\n` escapes are preserved by JSON, and quoting the value keeps the shell out of it:
+Set the variable to the key file's contents. Quoting the value keeps the shell out of it:
 
 ```bash
 export BIGQUERY_CREDENTIALS_JSON="$(jq -c . service-account-key.json)"
 ```
 
-`serviceAccountKeyJsonBase64` takes the same key base64-encoded, for pipelines and secret stores that mangle the quoting or the embedded newlines of raw JSON:
+The property also accepts the key base64-encoded, which is one unquoted token and so travels through shells, CI secret editors, and `.env` files more reliably than a blob of JSON braces and quotes:
 
 ```bash
-export BIGQUERY_CREDENTIALS_JSON_B64="$(base64 < service-account-key.json | tr -d '\n')"
+export BIGQUERY_CREDENTIALS_JSON="$(base64 < service-account-key.json | tr -d '\n')"
 ```
 
-Note that `serviceAccountKey` — the `json`-typed property — **cannot** take an environment variable reference. Like every `json` property, it treats `{"env": "..."}` as literal data, so that object itself becomes the credentials and BigQuery rejects it with `The incoming JSON object does not contain a client_email field`. Use one of the two `secret` properties above instead. If several are set, the order of precedence is `serviceAccountKey`, `serviceAccountKeyJson`, `serviceAccountKeyJsonBase64`.
+No flag distinguishes the two — the encoding is detected, since JSON always begins with `{` and `{` is not a base64 character. Surrounding whitespace is ignored, so a trailing newline from `$(cat …)` or a here-doc is harmless.
+
+Note that `serviceAccountKey` — the `json`-typed property — **cannot** take an environment variable reference. Like every `json` property, it treats `{"env": "..."}` as literal data, so that object itself becomes the credentials and BigQuery rejects it with `The incoming JSON object does not contain a client_email field`. Use `serviceAccountKeyJson` instead. If both are set, `serviceAccountKey` wins.
 
 ### `databricks` — Databricks
 


### PR DESCRIPTION
Docs for malloydata/malloy#3039, which adds `serviceAccountKeyJson` to the BigQuery connection — one `secret` string holding the whole key file, as JSON or base64, with the encoding detected rather than declared.

Two changes to `setup/config.malloynb`:

**The BigQuery section** gains the parameter, an example of pointing it at an environment variable, and the shell commands that produce each encoding (`jq -c` for JSON, `base64 | tr -d '\n'` for base64 — GNU `base64` wraps at 76 columns, which is awkward in an environment variable even though the decoder tolerates it). It notes that the encoding needs no flag because JSON always starts with `{` and `{` is not a base64 character, and that surrounding whitespace is ignored. It also mentions that with no key configured the connection falls back to application default credentials, which is what most local development is actually using.

The section says plainly that `serviceAccountKey` cannot take an `{"env": ...}` reference, and quotes the error BigQuery gives when someone tries — `The incoming JSON object does not contain a client_email field`. That string is the entire symptom, and it names neither the property nor the reason, so it is worth having in a page that search will find.

**The Environment Variables section** currently opens with "Any property value can be replaced with an environment variable reference," which isn't true of `json` properties. The `postgres` and `trino` sections each already carry a local correction for their own json properties; this adds the general statement in the place where someone forms the expectation, and points to the string-typed property to use instead.

No new pages and no anchor changes; the one new cross-link resolves to the existing `#bigquery-google-bigquery` heading, checked against the site's own `hashForHeading`.